### PR TITLE
Add OPENAI_BASE_URL enviroment variable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "vc-copilot-plugin",
-			"version": "1.0.0",
+			"version": "1.1.0",
 			"license": "MIT",
 			"dependencies": {
 				"openai": "^3.2.1"

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,10 +2,10 @@ import { App, Editor, MarkdownView, Modal, Notice, Plugin, PluginSettingTab, Set
 //import { WizardView, WIZARD_VIEW } from 'view';
 import * as fs from 'fs';
 import { execSync } from 'child_process';
-const { Configuration, OpenAIApi } = require("openai");
+import { Configuration, OpenAIApi } from "openai";
 import {get_startup_by_name, add_notes_to_company, get_person_by_name, get_person_details, is_person_in_venture_network, get_field_values, add_entry_to_list, add_field_value, add_notes_to_person} from "./utils";
 import { start } from 'repl';
-import { TextInputModal } from 'modal';
+import { TextInputModal } from './modal';
 import { exec} from "child_process";
 
 
@@ -54,6 +54,7 @@ const DEFAULT_SETTINGS: ButlerSettings = {
 async function openai_js(query: String, system_prompt: String, max_tokens: number = 256, temperature: number = 0.3){
     const configuration = new Configuration({
         apiKey: openaiAPIKey,
+        basePath: process.env.OPENAI_BASE_URL
       });
       //to avoid an annoying error/warning message
       delete configuration.baseOptions.headers['User-Agent'];


### PR DESCRIPTION
Hello! I added the possibility to pass the base path for the OpenAI endpoint, as an environment variable when running the node process. If nothing is passed the SDK will fallback to the OpenAI endpoint.

eg.

```sh
# replace the environment variable with the right endpoint
export OPENAI_BASE_URL=https://llama-2-13b-chat.demo.prem.ninja/v1 

# run the Node.js process
node main.js 
```

This way it's easy to switch from GPT4 to other compatible endpoints such as the ones exposed by the [Prem](https://www.premai.io) Desktop App